### PR TITLE
crude patch for removing stat.h usage in pd::mutex_t

### DIFF
--- a/pd/base/mutex.C
+++ b/pd/base/mutex.C
@@ -15,7 +15,6 @@ void mutex_t::lock() {
 	int oval = __sync_val_compare_and_swap(&val, 0, 1);
 
 	if(!oval) {
-		++stat.events()[pass];
 	}
 	else {
 		assert(oval == 1 || oval == 2);
@@ -32,16 +31,13 @@ void mutex_t::lock() {
 		if(tstate)
 			tstate->set(old_state);
 
-		++stat.events()[wait];
 	}
 
 	tid = thr::id;
 
-	stat.tstate().set(locked);
 }
 
 void mutex_t::unlock() {
-	stat.tstate().set(unlocked);
 
 	assert(val != 0);
 

--- a/pd/base/mutex.H
+++ b/pd/base/mutex.H
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <pd/base/lock_guard.H>
-#include <pd/base/stat.H>
 #include <pd/base/stat_items.H>
 
 #pragma GCC visibility push(default)
@@ -20,50 +19,17 @@ class mutex_t {
 
 	enum event_t { pass, wait };
 
-	struct ecount_t : stat::vcount_t<event_t, 2> {
-		inline ecount_t() :
-			stat::vcount_t<event_t, 2> (
-				STRING("pass"), STRING("wait")
-			) { }
-	};
-
 	enum state_t { unlocked, locked };
 
-	struct tstate_t : stat::tstate_t<state_t, 2> {
-		inline tstate_t() :
-			stat::tstate_t<state_t, 2> (
-				STRING("unlocked"), STRING("locked")
-			) { }
-	};
-
-	typedef stat::items_t<
-		ecount_t,
-		tstate_t
-	> stat_base_t;
-
 public:
-	struct stat_t : stat_base_t {
-		inline stat_t() throw() : stat_base_t(
-			STRING("events"),
-			STRING("tstate")
-		) { }
-
-		inline ~stat_t() throw() { }
-
-		inline ecount_t &events() { return item<0>(); }
-		inline tstate_t &tstate() { return item<1>(); }
-	};
-
-	stat_t stat;
-
-	inline mutex_t() throw() : val(0), tid(0), stat() { }
+	inline mutex_t() throw() : val(0), tid(0) { }
 
 	void lock();
 	void unlock();
 
-	inline void init() { stat.init(); }
+	inline void init() { }
 
-	inline void stat_print() { stat.print(); }
+	inline void stat_print() { }
 
 	inline ~mutex_t() throw() { assert(!tid); assert(!val); }
 

--- a/pd/bq/bq_cont.C
+++ b/pd/bq/bq_cont.C
@@ -70,7 +70,7 @@ unsigned int bq_spec_reserve() throw() {
 	return bq_spec_num++;
 }
 
-#if defined(__GXX_ABI_VERSION) && __GXX_ABI_VERSION == 1002
+#if defined(__GXX_ABI_VERSION) && __GXX_ABI_VERSION >= 1002
 
 struct __cxa_eh_globals {
 	void *caughtExceptions;

--- a/phantom/io_benchmark/method_stream/source_log/source_log.C
+++ b/phantom/io_benchmark/method_stream/source_log/source_log.C
@@ -6,6 +6,7 @@
 
 #include "../source.H"
 #include "../../../module.H"
+#include <pd/base/stat.H>
 
 #include <pd/base/config.H>
 #include <pd/base/exception.H>

--- a/phantom/io_client/proto_none/entry.I
+++ b/phantom/io_client/proto_none/entry.I
@@ -93,8 +93,8 @@ class entry_t {
 
 		inline ~tasks_t() throw() { if(tasks) delete [] tasks; }
 
-		inline void init() { stat::meta(stat, mutex.stat).init(); }
-		inline void stat_print() { stat::meta(stat, mutex.stat).print(); }
+		inline void init() { stat::meta(stat).init(); }
+		inline void stat_print() { stat::meta(stat).print(); }
 	};
 
 	tasks_t tasks;

--- a/phantom/jemalloc/jemalloc_.C
+++ b/phantom/jemalloc/jemalloc_.C
@@ -5252,8 +5252,6 @@ void setup_malloc_t::stat_print() const {
 void setup_malloc_t::fini() {
 	for(unsigned i = 0; i < narenas; i++) {
 		arena_t *arena = arenas[i];
-		if (arena != NULL) 
-			arena->lock.stat.__tmp_fini();
 	}
 }
 


### PR DESCRIPTION
This patch fixes infinite locks in pd::mutex_t for phantom compiled with gcc >4.9
