### PR TITLE
Initialize OpenSSL library in a way to read config-file.

### DIFF
--- a/pd/ssl/ssl.C
+++ b/pd/ssl/ssl.C
@@ -17,6 +17,7 @@
 #include <openssl/crypto.h>
 #include <openssl/ssl.h>
 #include <openssl/engine.h>
+#include <openssl/conf.h>
 
 namespace pd {
 
@@ -48,9 +49,17 @@ struct mgr_t {
 	}
 
 	inline mgr_t() throw() {
+		OPENSSL_load_builtin_modules();
+		ENGINE_load_builtin_engines();
+		ERR_clear_error();
+		if (CONF_modules_load_file(NULL, NULL, CONF_MFLAGS_DEFAULT_SECTION |
+                                                       CONF_MFLAGS_IGNORE_MISSING_FILE) <= 0) {
+                        fprintf(stderr, "FATAL: error loading configuration file\n");
+                        ERR_print_errors_fp(stderr);
+                        exit(1);
+                }
 		SSL_library_init();
 		SSL_load_error_strings();
-		ENGINE_load_builtin_engines();
 		OpenSSL_add_all_algorithms();
 
 		types = CRYPTO_num_locks();


### PR DESCRIPTION
Initialize OpenSSL library so it would read default config file.
Function OPENSSL_config() not called since it deprecated in OpenSSL>=1.1.0
